### PR TITLE
Added command to re-save after subsequent formatters run.

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -109,6 +109,7 @@ export default class Formatter {
             await commands.executeCommand(this.formatAction);
         }
 
+        await commands.executeCommand('workbench.action.files.save');
         // Return back to the original configuration
         await this.config.update('defaultFormatter', this.defaultFormatter, ConfigurationTarget.Workspace, true);
     }


### PR DESCRIPTION
issue #2 

All I did was add a command to save the file after the formatters run. I know it's technically an "unnecessary" save, and therefore a bit hacky, but it seems to at least be a temporary solution.