### PR TITLE
Increase configuration target precision

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -112,7 +112,7 @@ export default class Formatter {
         
         // decide which configuration file to update
         // "?? {}" handles the defaultFormatter absent case
-        const {workspaceLanguageValue, workspaceFolderLanguageValue} = config.inspect('defaultFormatter') ?? {};
+        const {workspaceLanguageValue, workspaceFolderLanguageValue} = this.config.inspect('defaultFormatter') ?? {};
         const configurationTarget = (
           typeof workspaceLanguageValue === 'string'                ? ConfigurationTarget.Workspace :
           typeof workspaceFolderLanguageValue === 'string'          ? ConfigurationTarget.WorkspaceFolder :

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -74,14 +74,7 @@ export default class Formatter {
         }
 
         this.isFormatting = true;
-        this.getFormattersForCurrentDocument();
-        const {workspaceLanguageValue, workspaceFolderLanguageValue} = config.inspect('defaultFormatter')!;
-        const configurationTarget = (
-          typeof workspaceLanguageValue === 'string'                ? ConfigurationTarget.Workspace :
-          typeof workspaceFolderLanguageValue === 'string'          ? ConfigurationTarget.WorkspaceFolder :
-          /* typeof globalLanguageValue === 'string' | undefined */   ConfigurationTarget.Global
-        );
-        await this.runFormatters(configurationTarget);
+        await this.runFormatters();
         this.isFormatting = false;
     }
 
@@ -114,7 +107,18 @@ export default class Formatter {
         }
     }
 
-    async runFormatters(configurationTarget: ConfigurationTarget) {
+    async runFormatters() {
+        this.getFormattersForCurrentDocument();
+        
+        // decide which configuration file to update
+        // "?? {}" handles the defaultFormatter absent case
+        const {workspaceLanguageValue, workspaceFolderLanguageValue} = config.inspect('defaultFormatter') ?? {};
+        const configurationTarget = (
+          typeof workspaceLanguageValue === 'string'                ? ConfigurationTarget.Workspace :
+          typeof workspaceFolderLanguageValue === 'string'          ? ConfigurationTarget.WorkspaceFolder :
+          /* typeof globalLanguageValue === 'string' | undefined */   ConfigurationTarget.Global
+        );
+        
         for (const formatter of this.formatters) {
             this.logger.appendLine(`Executing ${this.formatAction} with ${formatter}`);
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -110,9 +110,9 @@ export default class Formatter {
     async runFormatters() {
         this.getFormattersForCurrentDocument();
         
-        // decide which configuration file to update
-        // this check ensures we change defaultFormatter in the same configuration file where the user has it set
-        // the order of checks goes from the most specific to least specific
+        // The below check ensures we set editor.defaultFormatter in the same configuration location that it
+        // currently exists so we don't unexpectedly change where the user has their defaultFormatter set.
+        // The order of checks goes from the most specific to least specific location
         // "?? {}" handles the defaultFormatter absent case
         const {
             workspaceLanguageValue,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -59,12 +59,12 @@ export default class Formatter {
 
     async formatSelection() {
         this.formatAction = this.FORMAT_SELECTION_ACTION;
-        await this.runFormatters();
+        await this.format();
     }
 
     async formatDocument() {
         this.formatAction = this.FORMAT_DOCUMENT_ACTION;
-        await this.runFormatters();
+        await this.format();
     }
 
     private async format() {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -111,18 +111,29 @@ export default class Formatter {
         this.getFormattersForCurrentDocument();
         
         // decide which configuration file to update
+        // this check ensures we change defaultFormatter in the same configuration file where the user has it set
+        // the order of checks goes from the most specific to least specific
         // "?? {}" handles the defaultFormatter absent case
-        const {workspaceLanguageValue, workspaceFolderLanguageValue} = this.config.inspect('defaultFormatter') ?? {};
-        const configurationTarget = (
-          typeof workspaceLanguageValue === 'string'                ? ConfigurationTarget.Workspace :
-          typeof workspaceFolderLanguageValue === 'string'          ? ConfigurationTarget.WorkspaceFolder :
-          /* typeof globalLanguageValue === 'string' | undefined */   ConfigurationTarget.Global
+        const {
+            workspaceLanguageValue,
+            workspaceValue,
+            workspaceFolderLanguageValue,
+            workspaceFolderValue,
+            globalLanguageValue
+        } = this.config.inspect('defaultFormatter') ?? {};
+        const [configurationTarget, isLanguageSpecific] = (
+            typeof workspaceLanguageValue === 'string'        ? [ConfigurationTarget.Workspace, true] : 
+            typeof workspaceValue === 'string'                ? [ConfigurationTarget.Workspace, false] :
+            typeof workspaceFolderLanguageValue === 'string'  ? [ConfigurationTarget.WorkspaceFolder, true] :
+            typeof workspaceFolderValue === 'string'          ? [ConfigurationTarget.WorkspaceFolder, false] :
+            typeof globalLanguageValue === 'string'           ? [ConfigurationTarget.Global, true] :
+            /* typeof globalValue === string|undefined */       [ConfigurationTarget.Global, false]
         );
         
         for (const formatter of this.formatters) {
             this.logger.appendLine(`Executing ${this.formatAction} with ${formatter}`);
 
-            await this.config.update("defaultFormatter", formatter, configurationTarget, true);
+            await this.config.update("defaultFormatter", formatter, configurationTarget, isLanguageSpecific);
             await commands.executeCommand(this.formatAction);
         }
 
@@ -132,6 +143,6 @@ export default class Formatter {
         }
 
         // Return back to the original configuration
-        await this.config.update("defaultFormatter", this.defaultFormatter, configurationTarget, true);
+        await this.config.update("defaultFormatter", this.defaultFormatter, configurationTarget, isLanguageSpecific);
     }
 }


### PR DESCRIPTION
- Increases configuration target precision to cover a missing case (WorkspaceFolder)
- Remove try/catch that the increased precision makes unnecessary
- Move configurationTarget to runFormatters since it's only used there and moving it decreases complexity.

Note: this change comes from trying different settings files (workspace, user, workspaceFolder) in my own testing version of this plugin.  I haven't been able to clone/run this repo successfully yet, so I haven't been able to test it in this repo. I don't see anything that would work differently, but it's worth a close look to make sure I didn't miss anything specific to this repo.