### PR TITLE
Add JSON support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "onLanguage:html",
         "onLanguage:javascript",
         "onLanguage:javascriptreact",
+        "onLanguage:json",
         "onLanguage:markdown",
         "onLanguage:matlab",
         "onLanguage:mdx",

--- a/src/supported-languages.ts
+++ b/src/supported-languages.ts
@@ -6,6 +6,7 @@ export default [
     'html',
     'javascript',
     'javascriptreact',
+    'json',
     'markdown',
     'matlab',
     'mdx',


### PR DESCRIPTION
We use this extension (thanks) with Prettier and Biome, and the missing JSON formatting support doesn't really make sense. This just adds it.